### PR TITLE
Fix complie error on Linux kernel 3.6.1

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2024,7 +2024,7 @@ init_buffers        (struct v4l2_loopback_device *dev)
     b->length            = buffer_size;
     b->field             = V4L2_FIELD_NONE;
     b->flags             = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,6,1)
     b->input             = 0;
 #endif
     b->m.offset          = i * buffer_size;


### PR DESCRIPTION
On Linux Kernel 3.6.1, this version is removed 'input' member in v4l2_buffer structure.
thus, occured error on compiled v4l2loopback 0.6.1 with linux kernel 3.6.1.
I fix it and testing, it works well on my linux box.
