### PR TITLE
Fill in the v4l2_capability::bus_info field

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -567,9 +567,12 @@ vidioc_querycap     (struct file *file,
                      void *priv,
                      struct v4l2_capability *cap)
 {
+  struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
+
   strlcpy(cap->driver, "v4l2 loopback", sizeof(cap->driver));
   strlcpy(cap->card, "Dummy video device", sizeof(cap->card));
-  cap->bus_info[0]=0;
+  snprintf(cap->bus_info, sizeof(cap->bus_info), "v4l2loop:%d",
+           ((priv_ptr)video_get_drvdata(dev->vdev))->devicenr);
 
   cap->version = V4L2LOOPBACK_VERSION_CODE;
   cap->capabilities =


### PR DESCRIPTION
I was testing v4l2loopback with the WebRTC implementation in Firefox. The WebRTC code expects to use v4l2_capability::bus_info as a unique ID for a device, so it fails because the driver doesn't set it. This simple patch fills in bus_info (with an admittedly made-up ID), but it makes the WebRTC code happy.
