### PR TITLE
Set correct output buffer type in vidioc_dqbuf

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1553,6 +1553,7 @@ static int vidioc_dqbuf(struct file *file, void *private_data, struct v4l2_buffe
 		dprintkrw("output DQBUF index: %d\n", b->buffer.index);
 		unset_flags(b);
 		*buf = b->buffer;
+		buf->type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 		return 0;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
When userspace dequeues an output buffer from the driver, that buffer should
have type V4L2_BUF_TYPE_VIDEO_OUTPUT. Previously we were providing the type
from our internal buffer which is V4L2_BUF_TYPE_VIDEO_CAPTURE.

(I am trying to send video to the device using v4l2-ctl; it assumes the buffer returned from DQBUF has the correct type, and enqueues it again with QBUF without setting the type, so without this change it doesn't work.)
