### PR TITLE
Updated v4l2loopback.c to compile on >= 3.18 kernel

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -498,10 +498,15 @@ static ssize_t attr_store_maxopeners(struct device *cd,
 {
 	struct v4l2_loopback_device *dev = NULL;
 	unsigned long curr = 0;
-
+	
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,0)
+	if (kstrtoul(buf, 0, &curr))
+		return -EINVAL;
+	#else
 	if (strict_strtoul(buf, 0, &curr))
 		return -EINVAL;
-
+	#endif
+	
 	dev = v4l2loopback_cd2dev(cd);
 
 	if (dev->max_openers == curr)


### PR DESCRIPTION
Attempting to compile the module under 3.18 results in

```
/v4l2loopback/v4l2loopback.c:502:2: error: implicit declaration of function ‘strict_strtoul’ [-Werror=implicit-function-declaration]
  if (strict_strtoul(buf, 0, &curr))
  ^
cc1: some warnings being treated as errors
```

It seems that strict_strtoul has been removed from kernel.h on 3.18 and is possible to replace it with kstrtoul.
