### PR TITLE
add ondemandcam

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,11 @@
-TARGETS=test yuv4mpeg_to_v4l2
+TARGETS=test yuv4mpeg_to_v4l2 ondemandcam
 
 .PHONY: all clean
 
 all: $(TARGETS)
+
+ondemandcam: ondemandcam.c
+	gcc -o ondemandcam ondemandcam.c -lrt -lpthread
 
 clean:
 	-rm $(TARGETS)

--- a/examples/README
+++ b/examples/README
@@ -29,4 +29,18 @@ $ mkfifo /tmp/pipe
 $ ./yuv4mpeg_to_v4l2 < /tmp/pipe &
 $ mplayer movie.mp4 -vo yuv4mpeg:file=/tmp/pipe
 
+ondemandcam
+-----------
+Copyright 2015, tz@execpc.com, GPLv3.
+This will wait until something connects to pull frames then sends them.
+It uses two threads and semaphores to do the testing.
+It can setup and teardown the frame source.
+The example just sends a different color each second.
+It is 80x60 (it is a skeleton for hardware with this resolution)
 
+$ make ondemandcam
+$ ondemandcam /dev/videoX & # where X is the v4l2loopback device
+
+It can be viewed with:
+
+$ vlc v4l2:///dev/videoX # X is same device as above

--- a/examples/ondemandcam.c
+++ b/examples/ondemandcam.c
@@ -1,0 +1,130 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>                /* low-level i/o */
+#include <unistd.h>
+#include <signal.h>
+#include <errno.h>
+#include <malloc.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/ioctl.h>
+#include <linux/videodev2.h>
+#include <pthread.h>
+#include <semaphore.h>
+
+static char *v4l2dev = "/dev/video1";
+static int v4l2sink = -1;
+static int width = 80;                //640;    // Default for Flash
+static int height = 60;        //480;    // Default for Flash
+static char *vidsendbuf = NULL;
+static int vidsendsiz = 0;
+
+static void init_device() {
+
+}
+
+static void grab_frame() {
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    memset( vidsendbuf, 0, 3);
+    switch( ts.tv_sec & 3 ) {
+    case 0:
+        vidsendbuf[0] = 255;
+        break;
+    case 1:
+        vidsendbuf[0] = 255;
+        vidsendbuf[1] = 255;
+        break;
+    case 2:
+        vidsendbuf[1] = 255;
+        break;
+    case 3:
+        vidsendbuf[2] = 255;
+        break;
+    }
+    memcpy( vidsendbuf+3, vidsendbuf, vidsendsiz-3 );
+}
+
+static void stop_device() {
+
+}
+
+static void open_vpipe()
+{
+    v4l2sink = open(v4l2dev, O_WRONLY);
+    if (v4l2sink < 0) {
+        fprintf(stderr, "Failed to open v4l2sink device. (%s)\n", strerror(errno));
+        exit(-2);
+    }
+    // setup video for proper format
+    struct v4l2_format v;
+    int t;
+    v.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
+    t = ioctl(v4l2sink, VIDIOC_G_FMT, &v);
+    if( t < 0 )
+        exit(t);
+    v.fmt.pix.width = width;
+    v.fmt.pix.height = height;
+    v.fmt.pix.pixelformat = V4L2_PIX_FMT_RGB24;
+    vidsendsiz = width * height * 3;
+    v.fmt.pix.sizeimage = vidsendsiz;
+    t = ioctl(v4l2sink, VIDIOC_S_FMT, &v);
+    if( t < 0 )
+        exit(t);
+    vidsendbuf = malloc( vidsendsiz );
+}
+
+static pthread_t sender;
+static sem_t lock1,lock2;
+static void *sendvid(void *v)
+{
+    for (;;) {
+        sem_wait(&lock1);
+        if (vidsendsiz != write(v4l2sink, vidsendbuf, vidsendsiz))
+            exit(-1);
+        sem_post(&lock2);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    struct timespec ts;
+
+    if( argc == 2 )
+        v4l2dev = argv[1];
+
+    open_vpipe();
+
+    // open and lock response
+    if (sem_init(&lock2, 0, 1) == -1)
+        exit(-1);
+    sem_wait(&lock2);
+
+    if (sem_init(&lock1, 0, 1) == -1)
+        exit(-1);
+    pthread_create(&sender, NULL, sendvid, NULL);
+
+    for (;;) {
+        // wait until a frame can be written
+        fprintf( stderr, "Waiting for sink\n" );
+        sem_wait(&lock2);
+        // setup source
+        init_device(); // open and setup SPI
+        for (;;) {
+            grab_frame();
+            // push it out
+            sem_post(&lock1);
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_sec += 2;
+            // wait for it to get written (or is blocking)
+            if (sem_timedwait(&lock2, &ts))
+                break;
+        }
+        stop_device(); // close SPI
+    }
+    close(v4l2sink);
+    return 0;
+}


### PR DESCRIPTION
This is based on something I did long ago to get the Nokia N810 camera to work in Flash - which needed a V4L1 feed, but the camera was in V4L2.
I'm modding it so a FLIR Lepton module (80x60) can become a V4L2 device without doing a kernel driver or such, but thought I would share the mechanism for blocking until something actually requests video.