### PR TITLE
Fix issue #79

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -638,7 +638,11 @@ static int vidioc_querycap(struct file *file, void *priv, struct v4l2_capability
 
 	cap->version = V4L2LOOPBACK_VERSION_CODE;
 	cap->capabilities =
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
+		V4L2_CAP_STREAMING | V4L2_CAP_READWRITE | V4L2_CAP_DEVICE_CAPS;
+#else
 		V4L2_CAP_STREAMING | V4L2_CAP_READWRITE;
+#endif
 	if (dev->announce_all_caps) {
 		cap->capabilities |= V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_VIDEO_OUTPUT;
 	} else {
@@ -650,6 +654,9 @@ static int vidioc_querycap(struct file *file, void *priv, struct v4l2_capability
 			cap->capabilities |= V4L2_CAP_VIDEO_OUTPUT;
 		}
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
+    cap->device_caps = (cap->capabilities & ~V4L2_CAP_DEVICE_CAPS);
+#endif
 
 	memset(cap->reserved, 0, sizeof(cap->reserved));
 	return 0;


### PR DESCRIPTION
Linux 3.19 or later warn that set V4L2_CAP_DEVICE_CAPS flag in cap->capabilities and filled cap->device_caps.
cap->device_caps is set the cap->capabilities except V4L2_CAP_DEVICE_CAPS flag, but I got no warnings.