### PR TITLE
Module wouldn't compile on kernel 4.0

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2027,7 +2027,11 @@ static void init_vdev(struct video_device *vdev, int nr)
 	vdev->release      = &video_device_release;
 	vdev->minor        = -1;
 	if (debug > 1)
-		vdev->debug = V4L2_DEBUG_IOCTL | V4L2_DEBUG_IOCTL_ARG;
+		#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 20, 0)
+			vdev->debug = V4L2_DEBUG_IOCTL | V4L2_DEBUG_IOCTL_ARG;
+		#else
+			vdev->dev_debug = V4L2_DEV_DEBUG_IOCTL | V4L2_DEV_DEBUG_IOCTL_ARG;
+		#endif
 
 	/* since kernel-3.7, there is a new field 'vfl_dir' that has to be
 	 * set to VFL_DIR_M2M for bidrectional devices */


### PR DESCRIPTION
Fixed issue where module wouldn't compile due to some recent changes in v4l2-ioctl.h and v4l2-dev.h on kernel 4.0.
```
v4l2loopback/v4l2loopback.c: In function ‘init_vdev’:
v4l2loopback/v4l2loopback.c:2030:7: error: ‘struct video_device’ has no member named ‘debug’
v4l2loopback/v4l2loopback.c:2030:17: error: ‘V4L2_DEBUG_IOCTL’ undeclared (first use in this function)
v4l2loopback/v4l2loopback.c:2030:36: error: ‘V4L2_DEBUG_IOCTL_ARG’ undeclared (first use in this function)
```