### PR TITLE
Initialize bytesused also on output VIDIOC_QBUF.

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1503,7 +1503,10 @@ static int vidioc_qbuf(struct file *file, void *private_data, struct v4l2_buffer
 		return 0;
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
 		dprintkrw("output QBUF pos: %d index: %d\n", dev->write_position, index);
-		do_gettimeofday(&b->buffer.timestamp);
+		if (buf->timestamp.tv_sec == 0 && buf->timestamp.tv_usec == 0)
+			do_gettimeofday(&b->buffer.timestamp);
+		else
+			b->buffer.timestamp = buf->timestamp;
 		b->buffer.bytesused = buf->bytesused;
 		set_done(b);
 		buffer_written(dev, b);

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1504,6 +1504,7 @@ static int vidioc_qbuf(struct file *file, void *private_data, struct v4l2_buffer
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
 		dprintkrw("output QBUF pos: %d index: %d\n", dev->write_position, index);
 		do_gettimeofday(&b->buffer.timestamp);
+		b->buffer.bytesused = buf->bytesused;
 		set_done(b);
 		buffer_written(dev, b);
 		wake_up_all(&dev->read_event);


### PR DESCRIPTION
When an application submits an output buffer to the streaming interface, the
value of the bytesused field gets ignored and lost to subsequent consumers of
this buffer. This is OK for fixed-size data types, but it causes problems with
compressed sources, since they rely on this field to signal the actual size of
the data.

Thusly, this change enables using the streaming interface to transmit compressed
frame data.