### PR TITLE
Makefile: remove depmod call in modules_install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ v4l2loopback.ko:
 install-all: install install-utils install-man
 install:
 	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules_install
-	depmod -a  $(KERNELRELEASE)
 
 install-utils: utils/v4l2loopback-ctl
 	$(INSTALL_DIR) "$(DESTDIR)$(BINDIR)"


### PR DESCRIPTION
A call to depmod is not required - modules_install already does
this for us. Also this does not make sense when we are cross-compiling
the module, because depmod will be called against the host kernel. This call
also does not work if we are cross-compiling in a container where there is no
host kernel at all.

Signed-off-by: Todor Minchev <todor.minchev@linux.intel.com>