### PR TITLE
Adding support for NV12 as per umlaeute/v4l2loopback#169

### DIFF
--- a/v4l2loopback_formats.h
+++ b/v4l2loopback_formats.h
@@ -238,6 +238,14 @@
      .flags    = FORMAT_FLAGS_PLANAR,
      },
 #endif /* V4L2_PIX_FMT_Y41P */
+#ifdef V4L2_PIX_FMT_NV12
+{
+	.name     = "12 bpp Y/CbCr 4:2:0 ",
+		.fourcc   = V4L2_PIX_FMT_NV12,
+		.depth    = 12,
+		.flags    = FORMAT_FLAGS_PLANAR,
+     },
+#endif /* V4L2_PIX_FMT_NV12 */
 
  /* here come the compressed formats */
 


### PR DESCRIPTION
This branch add support for the NV12 missing format. Successful merge should close umlaeute/v4l2loopback#169