### PR TITLE
v4l2lookback: Port to kernel 5.4+

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2088,6 +2088,10 @@ static void init_vdev(struct video_device *vdev, int nr)
 	vdev->ioctl_ops    = &v4l2_loopback_ioctl_ops;
 	vdev->release      = &video_device_release;
 	vdev->minor        = -1;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+	vdev->device_caps  = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_VIDEO_OUTPUT |
+			     V4L2_CAP_READWRITE | V4L2_CAP_STREAMING;
+#endif
 	if (debug > 1)
 		#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 20, 0)
 			vdev->debug = V4L2_DEBUG_IOCTL | V4L2_DEBUG_IOCTL_ARG;


### PR DESCRIPTION
Since 5.4 video_register_device verifies that device_caps fields is
initialized and fails to return otherwise.

Fixes: https://github.com/umlaeute/v4l2loopback/issues/248
Signed-off-by: Ricardo Ribalda Delgado <ricardo@ribalda.com>