### PR TITLE
Mention exclusive_caps mode option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ will create 3 devices with the card names passed as the second parameter:
 - `/dev/video4` -> *the number four*
 - `/dev/video7` -> *the last one*
 
+
+if you encounter problems detecting your device with Chromium/WebRTC you can try 'exclusive_caps' mode:
+
+    # modprobe v4l2loopback exclusive_caps=1
+    
+will enable 'exclusive_caps' mode that only reports CAPTURE/OUTPUT capabilities exclusively (support for Chromium/WebRTC)
+[Details](https://github.com/umlaeute/v4l2loopback/issues/78#issuecomment-70320902)
+   
 # ATTRIBUTES
 you can set and/or query some per-device attributes via sysfs, in a human
 readable format. see `/sys/devices/virtual/video4linux/video*/`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ option, when loading the module; e.g.
     # modprobe v4l2loopback devices=4
 
 will give you 4 loopback devices (e.g. `/dev/video1` ... `/dev/video5`)
+
 you can also specify the device IDs manually; e.g.
 
     # modprobe v4l2loopback video_nr=3,4,7


### PR DESCRIPTION
Hey :wave: I only learned about the `exclusive_caps=1` option reading through closed issues.

I'm not sure how relevant it is still as I haven't encountered that bug myself so far, but I thought I document its existence somewhere where I could find it again, would I ever need it :)