### PR TITLE
Rename VFL_TYPE_GRABBER to VFL_TYPE_VIDEO on kernel 5.7.0 and up

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -36,6 +36,12 @@
 # define kstrtoul strict_strtoul
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+# define vfl_type_video VFL_TYPE_VIDEO
+#else
+# define vfl_type_video VFL_TYPE_GRABBER
+#endif
+
 #if defined(timer_setup) && defined(from_timer)
 #define HAVE_TIMER_SETUP
 #endif
@@ -2083,7 +2089,7 @@ static void init_vdev(struct video_device *vdev, int nr)
 	vdev->tvnorms      = V4L2_STD_ALL;
 #endif /* V4L2LOOPBACK_WITH_STD */
 
-	vdev->vfl_type     = VFL_TYPE_GRABBER;
+	vdev->vfl_type     = vfl_type_video;
 	vdev->fops         = &v4l2_loopback_fops;
 	vdev->ioctl_ops    = &v4l2_loopback_ioctl_ops;
 	vdev->release      = &video_device_release;
@@ -2432,7 +2438,7 @@ static int __init v4l2loopback_init_module(void)
 			return ret;
 		}
 		/* register the device -> it creates /dev/video* */
-		if (video_register_device(devs[i]->vdev, VFL_TYPE_GRABBER, video_nr[i]) < 0) {
+		if (video_register_device(devs[i]->vdev, vfl_type_video, video_nr[i]) < 0) {
 			video_device_release(devs[i]->vdev);
 			printk(KERN_ERR "v4l2loopback: failed video_register_device()\n");
 			free_devices();


### PR DESCRIPTION
I have tested and confirmed that this works on kernel 5.7-rc1.
I haven't tested this change on 5.6 yet, but I can't see how it would break something. Would probably still be a good idea for someone to test it though.