### PR TITLE
reset ready_for_capture flag processing VIDIOC_STREAMOFF

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1677,9 +1677,22 @@ static int vidioc_streamon(struct file *file, void *private_data, enum v4l2_buf_
  */
 static int vidioc_streamoff(struct file *file, void *private_data, enum v4l2_buf_type type)
 {
+	struct v4l2_loopback_device *dev;
 	MARK();
 	dprintk("%d\n", type);
-	return 0;
+
+        dev = v4l2loopback_getdevice(file);
+
+        switch (type) {
+        case V4L2_BUF_TYPE_VIDEO_OUTPUT:
+		dev->ready_for_capture = 0;
+                return 0;
+        case V4L2_BUF_TYPE_VIDEO_CAPTURE:
+                return 0;
+        default:
+                return -EINVAL;
+        }
+        return -EINVAL;
 }
 
 #ifdef CONFIG_VIDEO_V4L1_COMPAT


### PR DESCRIPTION
Hi,

When calling on a V4L2_BUF_TYPE_VIDEO_OUTPUT device VIDIOC_STREAMON, it is no more possible to change the format using VIDIOC_S_FMT.
It keeps the old format.    
This pull request reset the ready_for_capture processing VIDIOC_STREAMOFF, it is then possible to change the format and then call again VIDIOC_STREAMON.

Best Regards,
Michel.