### PR TITLE
utils: respect CPPFLAGS from env vars

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,3 +1,3 @@
-CPPFLAGS = -I..
+CPPFLAGS += -I..
 
 default: v4l2loopback


### PR DESCRIPTION
Packaging systems might inject extra CPPFLAGS, e.g. _FORTIFY_SOURCE.

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>