### PR TITLE
try to set requested colorspace

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -995,7 +995,10 @@ static int vidioc_try_fmt_out(struct file *file, void *priv,
 		pix_format_set_size(&fmt->fmt.pix, format, w, h);
 
 		fmt->fmt.pix.pixelformat = format->fourcc;
-		fmt->fmt.pix.colorspace = V4L2_COLORSPACE_SRGB;
+
+		if ((fmt->fmt.pix.colorspace == V4L2_COLORSPACE_DEFAULT) ||
+		    (fmt->fmt.pix.colorspace > V4L2_COLORSPACE_DCI_P3))
+			fmt->fmt.pix.colorspace = V4L2_COLORSPACE_SRGB;
 
 		if (V4L2_FIELD_ANY == fmt->fmt.pix.field)
 			fmt->fmt.pix.field = V4L2_FIELD_NONE;


### PR DESCRIPTION
There's a problem that v4l2loopback forcing video output colorspace to SRGB. On the capture side, we wanted to use v4l2h264enc with gst-launch-1.0, but it didn't accept "2:4:7:1" colorimetry selected by v4l2loopback somehow, so we had to use videoconvert which is CPU intensive. So, I modified vidioc_try_fmt_out() to use the specified colorspace if the value is valid. Now, I can set colorimetry to 'bt709' with gstreamer caps using v4l2loopback as v4l2sink.

As I don't know v4l2 well, maybe my condition check is not really correct. But this fixed at least the problem we were facing.