### PR TITLE
Allow reading buffered frames

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1616,7 +1616,7 @@ static int get_capture_buffer(struct file *file)
 		      dev->used_buffers;
 	} else {
 		opener->reread_count = 0;
-		if (dev->write_position > opener->read_position + 2)
+		if (dev->write_position > opener->read_position + dev->used_buffers)
 			opener->read_position = dev->write_position - 1;
 		pos = opener->read_position % dev->used_buffers;
 		++opener->read_position;


### PR DESCRIPTION
Why:

If userspace reader is blocked for some reason, it is expected that when
reading continues, frames are not dropped unless the buffer overflows.

Currently, if reader is more than one frame behind writer, next read
skips to newest frame.

It seems that allowing read from buffer is in line with how uvc v4l2
devices work.

What:

Change skipping threshold so that skipping happens only when buffer
overflows.