### PR TITLE
fix build against kernel older than v4.4 due to VIDIOC_QUERY_EXT_CTRL undefined

### DIFF
--- a/utils/v4l2loopback.c
+++ b/utils/v4l2loopback.c
@@ -149,13 +149,15 @@ static unsigned int _get_control_id(int fd, const char *control)
 	const size_t length = strnlen(control, 1024);
 	const unsigned next = V4L2_CTRL_FLAG_NEXT_CTRL;
 	struct v4l2_queryctrl qctrl;
+	int id;
+
 	memset(&qctrl, 0, sizeof(qctrl));
 	while (ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0) {
 		if (!strncmp(qctrl.name, control, length))
 			return qctrl.id;
 		qctrl.id |= next;
 	}
-	for (int id = V4L2_CID_USER_BASE; id < V4L2_CID_LASTP1; id++) {
+	for (id = V4L2_CID_USER_BASE; id < V4L2_CID_LASTP1; id++) {
 		qctrl.id = id;
 		if (ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0) {
 			if (!strncmp(qctrl.name, control, length))

--- a/utils/v4l2loopback.c
+++ b/utils/v4l2loopback.c
@@ -148,22 +148,22 @@ static unsigned int _get_control_id(int fd, const char *control)
 {
 	const size_t length = strnlen(control, 1024);
 	const unsigned next = V4L2_CTRL_FLAG_NEXT_CTRL;
-	struct v4l2_query_ext_ctrl qctrl;
+	struct v4l2_queryctrl qctrl;
 	memset(&qctrl, 0, sizeof(qctrl));
-	while (ioctl(fd, VIDIOC_QUERY_EXT_CTRL, &qctrl) == 0) {
+	while (ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0) {
 		if (!strncmp(qctrl.name, control, length))
 			return qctrl.id;
 		qctrl.id |= next;
 	}
 	for (int id = V4L2_CID_USER_BASE; id < V4L2_CID_LASTP1; id++) {
 		qctrl.id = id;
-		if (ioctl(fd, VIDIOC_QUERY_EXT_CTRL, &qctrl) == 0) {
+		if (ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0) {
 			if (!strncmp(qctrl.name, control, length))
 				return qctrl.id;
 		}
 	}
 	for (qctrl.id = V4L2_CID_PRIVATE_BASE;
-	     ioctl(fd, VIDIOC_QUERY_EXT_CTRL, &qctrl) == 0; qctrl.id++) {
+	     ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0; qctrl.id++) {
 		if (!strncmp(qctrl.name, control, length)) {
 			unsigned int id = qctrl.id;
 			return id;


### PR DESCRIPTION
This fixes following errors. Kernel v4.4 is the first known working version.
```
make[1]: Entering directory `/work/vicamo/canonical/dkms/v4l2loopback/v4l2loopback/utils'
cc  -I..   v4l2loopback.c   -o v4l2loopback
v4l2loopback.c: In function '_get_control_id':
v4l2loopback.c:151:29: error: storage size of 'qctrl' isn't known
  struct v4l2_query_ext_ctrl qctrl;
                             ^
v4l2loopback.c:153:19: error: 'VIDIOC_QUERY_EXT_CTRL' undeclared (first use in this function)
  while (ioctl(fd, VIDIOC_QUERY_EXT_CTRL, &qctrl) == 0) {
                   ^
v4l2loopback.c:153:19: note: each undeclared identifier is reported only once for each function it appears in
v4l2loopback.c:158:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for (int id = V4L2_CID_USER_BASE; id < V4L2_CID_LASTP1; id++) {
  ^
v4l2loopback.c:158:2: note: use option -std=c99 or -std=gnu99 to compile your code
v4l2loopback.c: In function 'print_conf':
v4l2loopback.c:291:3: warning: format '%s' expects argument of type 'char *', but argument 2 has type 'struct v4l2_loopback_config *' [-Wformat=]
   printf("configuration: %s\n", cfg);
   ^
v4l2loopback.c: In function 'parse_caps':
v4l2loopback.c:492:6: warning: format '%c' expects argument of type 'char *', but argument 3 has type 'char (*)[5]' [-Wformat=]
      &caps->height, &caps->fps_num, &caps->fps_denom) <= 0) {
      ^
v4l2loopback.c:494:7: warning: format '%c' expects argument of type 'char *', but argument 3 has type 'char (*)[5]' [-Wformat=]
       &caps->height, &caps->fps_num) <= 0) {
       ^
v4l2loopback.c:494:7: warning: too many arguments for format [-Wformat-extra-args]
make[1]: *** [v4l2loopback] Error 1
make[1]: Leaving directory `/work/vicamo/canonical/dkms/v4l2loopback/v4l2loopback/utils'
make: *** [utils/v4l2loopback] Error 2
```