### PR TITLE
ci: match known failures to kernel versions

### DIFF
--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -17,7 +17,7 @@ jobs:
         series: [trusty, xenial, bionic, focal, groovy]
     container: buildpack-deps:${{ matrix.series }}
     env:
-      JOB_KNOWN_FAILURES: "3.13.0-170-generic"
+      JOB_KNOWN_FAILURES: "3.13"
     steps:
       - uses: actions/checkout@v2
 
@@ -36,7 +36,7 @@ jobs:
               modinfo v4l2loopback.ko;
             else
               case " ${JOB_KNOWN_FAILURES} " in
-              *${kver}*)
+              *" ${kver%.*} "*)
                 echo "#### Skipped known failure ${kver}";
                 ;;
               *)


### PR DESCRIPTION
While Ubuntu may have new updates after marking a known failure, matching a specific package version is not so correct. This change matches kernel major.minor version instead.

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>