### PR TITLE
Include header outside of struct definition

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -458,9 +458,7 @@ struct v4l2l_format {
 #define FORMAT_FLAGS_PLANAR 0x01
 #define FORMAT_FLAGS_COMPRESSED 0x02
 
-static const struct v4l2l_format formats[] = {
 #include "v4l2loopback_formats.h"
-};
 
 static const unsigned int FORMATS = ARRAY_SIZE(formats);
 

--- a/v4l2loopback_formats.h
+++ b/v4l2loopback_formats.h
@@ -1,3 +1,4 @@
+static const struct v4l2l_format formats[] = {
 #ifndef V4L2_PIX_FMT_VP9
 #define V4L2_PIX_FMT_VP9 v4l2_fourcc('V', 'P', '9', '0')
 #endif
@@ -425,3 +426,4 @@
 		.flags = FORMAT_FLAGS_COMPRESSED,
 	},
 #endif /* V4L2_PIX_FMT_HEVC */
+};


### PR DESCRIPTION
Make gcc DWARF generator work by moving struct definition inside header file.

(This patch is from [the openSUSE package](https://build.opensuse.org/package/view_file/openSUSE:Factory/v4l2loopback/v4l2loopback-include_header.patch?expand=1) and needed to fix the build on Fedora and openSUSE)

Reference: https://bugzilla.opensuse.org/1159777