### PR TITLE
confine v4l2loopback_cleanup_module

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2862,6 +2862,7 @@ error:
 	return err;
 }
 
+#ifdef MODULE
 static void v4l2loopback_cleanup_module(void)
 {
 	MARK();
@@ -2871,6 +2872,7 @@ static void v4l2loopback_cleanup_module(void)
 	misc_deregister(&v4l2loopback_misc);
 	dprintk("module removed\n");
 }
+#endif
 
 MODULE_ALIAS_MISCDEV(MISC_DYNAMIC_MINOR);
 MODULE_ALIAS("devname:v4l2loopback");


### PR DESCRIPTION
In case v4l2loopback gets embedded into a full kernel tree and is
compiled as a built-in for whatever reason, the
v4l2loopback_cleanup_module routine is reported as unused because it is
called on module unload only, which is not compiled in case of built-in.

Fix this by decorating v4l2loopback_cleanup_module with another ifdef.

Signed-off-by: Oleksandr Natalenko <oleksandr@natalenko.name>