### PR TITLE
Fix the dkms install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,9 @@ E.g. to build the v4l2loopback-v0.12.5 (but check the webpage for newer releases
 use something like the following (you might need to run the `dkms` commands as superuser/root):
 
 ~~~
-mkdir -p ~/src/
-cd ~/src/
 version=0.12.5
-# download and extract the tarball
-curl -L https://github.com/umlaeute/v4l2loopback/archive/v${version}.tar.gz | tar xvz
+# download and extract the tarball (tar requires superuser privileges)
+curl -L https://github.com/umlaeute/v4l2loopback/archive/v${version}.tar.gz | tar xvz -C /usr/src
 # build and install the DKMS-module (requires superuser privileges)
 dkms add -m v4l2loopback -v ${version}
 dkms build -m v4l2loopback -v ${version}


### PR DESCRIPTION
Thanks for the great tool!

I realized though, that `dkms add` expects the source to be in `/usr/src/<module>-<module-version>/`, see [man dkms](https://manpages.ubuntu.com/manpages/precise/man8/dkms.8.html).
This PR fixes the regarding install instructions in the Readme by putting the v4l2loopback source into `/usr/src/` when extracting with tar.