### PR TITLE
Update README.md for consistent label quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can also specify the device IDs manually; e.g.
 
 Will create 3 devices (`/dev/video3`, `/dev/video4` & `/dev/video7`)
 
-    # modprobe v4l2loopback video_nr=3,4,7 card_label="device number 3","the number four","the last one"
+    # modprobe v4l2loopback video_nr=3,4,7 card_label="device number 3,the number four,the last one"
 
 Will create 3 devices with the card names passed as the second parameter:
 - `/dev/video3` -> *device number 3*


### PR DESCRIPTION
Thanks for your comments on the previous PR.
Indeed I had overlooked that the form under loading
at boot was correct. What about this:

Currently README.md contains two different quote styles
for card labels, namely for the shell (under OPTIONS):

    card_label="device number 3","the number four"

and further down under LOAD THE MODULE AT BOOT:

    card_label="device number 3,the number four"

Using the first form in `/etc/modprobe.d/v4l2loopback.conf`
leads to erroneous quotes in the device names.  Even though
for typing `modprobe` in the shell both forms are equivalent,
I'm aligning the first to the second to avoid confusion.