### PR TITLE
dkms: skip building utils

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -2,7 +2,7 @@ PACKAGE_NAME="v4l2loopback"
 PACKAGE_VERSION="0.12.5"
 
 # Items below here should not have to change with each driver version
-MAKE[0]="make KERNEL_DIR=${kernel_source_dir} all"
+MAKE[0]="make KERNEL_DIR=${kernel_source_dir} v4l2loopback"
 CLEAN="make clean"
 
 BUILT_MODULE_NAME[0]="$PACKAGE_NAME"


### PR DESCRIPTION
dkms build environment may not have build-deps for utils installed, and they should not be mixed as utils are built in binary package build time, and dkms are compiled at package installation time.

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>