### PR TITLE
ci: test against kernels in ubuntu hirsute as well

### DIFF
--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        series: [trusty, xenial, bionic, focal, groovy]
+        series: [trusty, xenial, bionic, focal, groovy, hirsute]
     container: buildpack-deps:${{ matrix.series }}
     env:
       JOB_KNOWN_FAILURES: "3.13 3.16 3.19 4.2"


### PR DESCRIPTION
Ubuntu Hirsute is to be released in 2021 Apr soon, and its related resources (docker image, apt repo) have been available long ago. Let's include it in the test matrix for testing against v5.10 kernel.

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>