### PR TITLE
ci: add clang-format-checks

### DIFF
--- a/.github/workflows/clang-format-checks.yml
+++ b/.github/workflows/clang-format-checks.yml
@@ -1,0 +1,29 @@
+name: kmod compatibility checks
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    container: buildpack-deps:sid-scm
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check clang-format
+        shell: bash
+        run: |
+          apt-get update --quiet
+          apt-get install --yes --no-install-recommends make clang-format
+
+          make clang-format
+          if [ -n "$(git status -s)" ]; then
+            git diff
+            exit 1
+          fi

--- a/utils/v4l2loopback-ctl.c
+++ b/utils/v4l2loopback-ctl.c
@@ -313,8 +313,7 @@ static void help_setcaps(const char *program, int brief, int argc, char **argv)
 			   "\n------------------"
 			   "\n");
 		char fourcc[5];
-		const size_t num_formats =
-			sizeof(formats) / sizeof(*formats);
+		const size_t num_formats = sizeof(formats) / sizeof(*formats);
 		size_t i = 0;
 		for (i = 0; i < num_formats; i++) {
 			const struct v4l2l_format *fmt = formats + i;

--- a/v4l2loopback_formats.h
+++ b/v4l2loopback_formats.h
@@ -6,13 +6,13 @@ static const struct v4l2l_format formats[] = {
 #define V4L2_PIX_FMT_HEVC v4l2_fourcc('H', 'E', 'V', 'C')
 #endif
 
-/* here come the packed formats */
-{
-	.name = "32 bpp RGB, le",
-	.fourcc = V4L2_PIX_FMT_BGR32,
-	.depth = 32,
-	.flags = 0,
-},
+	/* here come the packed formats */
+	{
+		.name = "32 bpp RGB, le",
+		.fourcc = V4L2_PIX_FMT_BGR32,
+		.depth = 32,
+		.flags = 0,
+	},
 	{
 		.name = "32 bpp RGB, be",
 		.fourcc = V4L2_PIX_FMT_RGB32,


### PR DESCRIPTION
clang-format of different versions may produce different output. This change uses clang-format from Debian Sid.

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>