### PR TITLE
fix v4l2 compliance errors

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -983,7 +983,6 @@ static int vidioc_enum_fmt_out(struct file *file, void *fh,
 		if (NULL == fmt)
 			return -EINVAL;
 
-		f->type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 		/* f->flags = ??; */
 		snprintf(f->description, sizeof(f->description), "%s",
 			 fmt->name);

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -760,10 +760,6 @@ static int vidioc_querycap(struct file *file, void *priv,
 	cap->version = V4L2LOOPBACK_VERSION_CODE;
 #endif
 
-#ifdef V4L2_CAP_VIDEO_M2M
-	capabilities |= V4L2_CAP_VIDEO_M2M;
-#endif /* V4L2_CAP_VIDEO_M2M */
-
 	if (dev->announce_all_caps) {
 		capabilities |= V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_VIDEO_OUTPUT;
 	} else {
@@ -2251,9 +2247,6 @@ static void init_vdev(struct video_device *vdev, int nr)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
 	vdev->device_caps = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_VIDEO_OUTPUT |
 			    V4L2_CAP_READWRITE | V4L2_CAP_STREAMING;
-#ifdef V4L2_CAP_VIDEO_M2M
-	vdev->device_caps |= V4L2_CAP_VIDEO_M2M;
-#endif
 #endif /* >=linux-4.7.0 */
 
 	if (debug > 1)


### PR DESCRIPTION
This patch set attempts to address a few issues reported by `v4l2-compliance` in regard to format size/interval enumeration in both capture and output size. With this patch set, the tests in the output side (before ready-to-capture) should be all green, but those in the capture side (after ready-to-capture) still fail due to the nature of combined output/capture device in v4l2loopback.