### PR TITLE
v4l2loopback.c: resource leak in v4l2_loopback_open()

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2005,6 +2005,7 @@ static int v4l2_loopback_open(struct file *file)
 
 		if (r < 0) {
 			dprintk("timeout image allocation failed\n");
+			kfree(opener);
 			return r;
 		}
 	}


### PR DESCRIPTION
Coverity discovered a resource leak in an error path.

CID 114123 (#2 of 2): Resource leak (RESOURCE_LEAK)
9. leaked_storage: Variable opener going out of scope leaks the storage it points to.

Signed-off-by: Tim Gardner <tim.gardner@canonical.com>