### PR TITLE
v4l2loopback.c: NULL dereference in free_buffers()

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2122,6 +2122,8 @@ static int free_buffers(struct v4l2_loopback_device *dev)
 {
 	MARK();
 	dprintk("freeing image@%p for dev:%p\n", dev ? dev->image : NULL, dev);
+	if (!dev)
+		return 0;
 	if (dev->image) {
 		vfree(dev->image);
 		dev->image = NULL;


### PR DESCRIPTION
Coverity found a possible NULL dereference after NULL check.

CID 114122 (#1 of 1): Dereference after null check (FORWARD_NULL)
5. var_deref_op: Dereferencing null pointer dev.

Signed-off-by: Tim Gardner <tim.gardner@canonical.com>