### PR TITLE
more coverity fixes

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -456,6 +456,9 @@ static ssize_t attr_store_format(struct device *cd,
 	struct v4l2_loopback_device *dev = v4l2loopback_cd2dev(cd);
 	unsigned int fps_num = 0, fps_den = 1;
 
+	if (!dev)
+		return -ENODEV;
+
 	/* only fps changing is supported */
 	if (sscanf(buf, "@%u/%u", &fps_num, &fps_den) > 0) {
 		struct v4l2_fract f = { .numerator = fps_den,
@@ -475,6 +478,9 @@ static ssize_t attr_show_buffers(struct device *cd,
 				 struct device_attribute *attr, char *buf)
 {
 	struct v4l2_loopback_device *dev = v4l2loopback_cd2dev(cd);
+
+	if (!dev)
+		return -ENODEV;
 
 	return sprintf(buf, "%u\n", dev->used_buffers);
 }

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2131,7 +2131,9 @@ v4l2_loopback_add(struct v4l2_loopback_config *conf)
 	init_vdev(dev->vdev, nr, conf->debug);
 	dev->vdev->v4l2_dev = &dev->v4l2_dev;
 	init_capture_param(&dev->capture_param);
-	set_timeperframe(dev, &dev->capture_param.timeperframe);
+	err = set_timeperframe(dev, &dev->capture_param.timeperframe);
+	if (err)
+		goto out_unregister;
 	dev->keep_format = 0;
 	dev->sustain_framerate = 0;
 
@@ -2186,6 +2188,8 @@ v4l2_loopback_add(struct v4l2_loopback_config *conf)
 	dev->v4l2_dev.ctrl_handler = hdl;
 
 	err = v4l2_ctrl_handler_setup(hdl);
+	if (err)
+		goto out_free_handler;
 
 	/* FIXME set buffers to 0 */
 
@@ -2200,7 +2204,9 @@ v4l2_loopback_add(struct v4l2_loopback_config *conf)
 	dev->buffer_size = PAGE_ALIGN(dev->pix_format.sizeimage);
 	dprintk("buffer_size = %ld (=%u)\n", dev->buffer_size,
 		dev->pix_format.sizeimage);
-	allocate_buffers(dev);
+	err = allocate_buffers(dev);
+	if (err)
+		goto out_free_handler;
 
 	init_waitqueue_head(&dev->read_event);
 


### PR DESCRIPTION
This maps to the attempt to fix the remaining coverity errors found in [LP: #1930208](https://bugs.launchpad.net/ubuntu/+source/v4l2loopback/+bug/1930208) for security reviews.