### PR TITLE
Add MODULE_VERSION macro

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -61,6 +61,7 @@ MODULE_AUTHOR("Vasily Levin, "
 	      "Stefan Diewald,"
 	      "Anton Novikov"
 	      "et al.");
+MODULE_VERSION("0.12.5");	      
 MODULE_LICENSE("GPL");
 
 /*


### PR DESCRIPTION
Add MODULE_VERSION macro so that the version can be read by using modinfo or `cat /sys/module/v4l2loopback/version` when the module was inserted with insmod.