### PR TITLE
Fix currentversion.sh to return the value

### DIFF
--- a/currentversion.sh
+++ b/currentversion.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-grep "^#define V4L2LOOPBACK_VERSION_CODE KERNEL_VERSION" v4l2loopback.c \
-| sed -e 's|^#define V4L2LOOPBACK_VERSION_CODE KERNEL_VERSION||' \
-      -e 's|^[^0-9]*||' -e 's|[^0-9]*$||' \
-      -e 's|[^0-9][^0-9]*|.|g'
+function num() {
+	grep "^#define V4L2LOOPBACK_VERSION_$1 " v4l2loopback.h | awk '{print $3}'
+}
+
+echo `num "MAJOR"`.`num "MINOR"`.`num "BUGFIX"`


### PR DESCRIPTION
v4l2loopback.c 's representation of the version number changed, and now it's out of step with the way the current version script expects to find it.  This updates the currentversion.sh script to get it from v4l2loopback.h