### PR TITLE
Send open/close hints to userspace

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -24,6 +24,7 @@
 #include <linux/fs.h>
 #include <linux/capability.h>
 #include <linux/eventpoll.h>
+#include <linux/wait.h>
 #include <media/v4l2-ioctl.h>
 #include <media/v4l2-common.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
@@ -279,6 +280,8 @@ MODULE_PARM_DESC(max_height,
 
 static DEFINE_IDR(v4l2loopback_index_idr);
 static DEFINE_MUTEX(v4l2loopback_ctl_mutex);
+static DECLARE_WAIT_QUEUE_HEAD(hint_waitqueue);
+static struct v4l2_loopback_hint current_hint;
 
 /* control IDs */
 #ifndef HAVE__V4L2_CTRLS
@@ -1994,7 +1997,10 @@ static int v4l2_loopback_open(struct file *file)
 {
 	struct v4l2_loopback_device *dev;
 	struct v4l2_loopback_opener *opener;
+	uid_t uid;
+	pid_t pid;
 	MARK();
+
 	dev = v4l2loopback_getdevice(file);
 	if (dev->open_count.counter >= dev->max_openers)
 		return -EBUSY;
@@ -2002,6 +2008,15 @@ static int v4l2_loopback_open(struct file *file)
 	opener = kzalloc(sizeof(*opener), GFP_KERNEL);
 	if (opener == NULL)
 		return -ENOMEM;
+
+	// Hint to userspace that this device file is being opened
+	pid = task_pid_nr(current);
+	uid = __kuid_val(current->cred->uid);
+	current_hint.type = HINT_OPEN;
+	current_hint.pid = pid;
+	current_hint.uid = uid;
+	current_hint.node = dev->vdev->num;
+	wake_up_interruptible(&hint_waitqueue);
 
 	v4l2_fh_init(&opener->fh, video_devdata(file));
 	file->private_data = &opener->fh;
@@ -2030,10 +2045,21 @@ static int v4l2_loopback_close(struct file *file)
 	struct v4l2_loopback_opener *opener;
 	struct v4l2_loopback_device *dev;
 	int iswriter = 0;
+	uid_t uid;
+	pid_t pid;
 	MARK();
 
 	opener = fh_to_opener(file->private_data);
 	dev = v4l2loopback_getdevice(file);
+
+	// Hint to userspace that this device file is being closed
+	pid = task_pid_nr(current);
+	uid = __kuid_val(current->cred->uid);
+	current_hint.type = HINT_CLOSE;
+	current_hint.pid = pid;
+	current_hint.uid = uid;
+	current_hint.node = dev->vdev->num;
+	wake_up_interruptible(&hint_waitqueue);
 
 	if (WRITER == opener->type)
 		iswriter = 1;
@@ -2574,6 +2600,22 @@ static void v4l2_loopback_remove(struct v4l2_loopback_device *dev)
 	kfree(dev);
 }
 
+static ssize_t v4l2loopback_control_read(struct file *file, char __user *buf,
+			size_t count, loff_t *f_pos)
+{
+	if (count != sizeof(struct v4l2_loopback_hint))
+		return -EINVAL;
+
+	wait_event_interruptible(hint_waitqueue, current_hint.type != HINT_UNKNOWN);
+	if (copy_to_user((void *)buf, (void*)&current_hint, count)) {
+		printk(KERN_ERR
+		       "v4l2-loopback: failed copy_to_user() in control read\n");
+		return -EFAULT;
+	}
+	current_hint.type = HINT_UNKNOWN;
+	return count;
+}
+
 static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 				       unsigned long parm)
 {
@@ -2682,6 +2724,7 @@ static const struct file_operations v4l2loopback_ctl_fops = {
 	// clang-format off
 	.owner		= THIS_MODULE,
 	.open		= nonseekable_open,
+	.read		= v4l2loopback_control_read,
 	.unlocked_ioctl	= v4l2loopback_control_ioctl,
 	.compat_ioctl	= v4l2loopback_control_ioctl,
 	.llseek		= noop_llseek,
@@ -2862,6 +2905,8 @@ static int __init v4l2loopback_init_module(void)
 			goto error;
 		}
 	}
+
+	current_hint.type = HINT_UNKNOWN;
 
 	dprintk("module installed\n");
 

--- a/v4l2loopback.h
+++ b/v4l2loopback.h
@@ -71,6 +71,22 @@ struct v4l2_loopback_config {
 	int debug;
 };
 
+/* For reads of v4l2 buffers, allow userspace to get hints from
+ * the kernel, to produce buffers on demand or to spawn permission dialogs.
+ */
+enum v4l2_loopback_hint_type {
+	HINT_UNKNOWN = 0,
+	HINT_OPEN,
+	HINT_CLOSE
+};
+
+struct v4l2_loopback_hint {
+	enum v4l2_loopback_hint_type type;
+	uid_t uid;
+	pid_t pid;
+	int node;
+};
+
 /* a pointer to a (struct v4l2_loopback_config) that has all values you wish to impose on the
  * to-be-created device set.
  * if the ptr is NULL, a new device is created with default values at the driver's discretion.


### PR DESCRIPTION
Allow the kernel module to send hints to userspace, via reading
the v4l2loopback control device, regarding access of v4l2 device nodes.

This will allow frame producers to determine when to pause production
or to show permission dialogs on behalf of the camera bridge system.

If additional hints are desired, those can be added post-merge by appending
the hint at hand in the enum after the existing values.