### PR TITLE
vidioc_reqbufs: do not init buffers if count = 0

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1489,12 +1489,13 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 		return 0;
 	}
 
+	/* do nothing here, buffers are always allocated */
+	if (b->count < 1 || dev->buffers_number < 1)
+		return 0;
+
 	init_buffers(dev);
 	switch (b->memory) {
 	case V4L2_MEMORY_MMAP:
-		/* do nothing here, buffers are always allocated */
-		if (b->count < 1 || dev->buffers_number < 1)
-			return 0;
 
 		if (b->count > dev->buffers_number)
 			b->count = dev->buffers_number;


### PR DESCRIPTION
in case of a count = 0, the buffers should not be inited
as it might break a conccurent access.

See #454