### PR TITLE
Limit v4l2_loopback_write calls to (streaming) writers

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2087,15 +2087,17 @@ static ssize_t v4l2_loopback_read(struct file *file, char __user *buf,
 static ssize_t v4l2_loopback_write(struct file *file, const char __user *buf,
 				   size_t count, loff_t *ppos)
 {
+	struct v4l2_loopback_opener *opener;
 	struct v4l2_loopback_device *dev;
 	int write_index;
 	struct v4l2_buffer *b;
 	MARK();
 
 	dev = v4l2loopback_getdevice(file);
+	opener = fh_to_opener(file->private_data);
 
-	/* there's at least one writer, so don't stop announcing output capabilities */
-	dev->ready_for_output = 0;
+	if (WRITER != opener->type)
+		return -EINVAL;
 
 	if (!dev->ready_for_capture) {
 		int ret = allocate_buffers(dev);


### PR DESCRIPTION
Previously whenever someone called the `write` function on the loopback device
the device was put in a state where no further openers could request access
to write frames to the device. While the intention of this is correct it
was missing to also make that opener doing the `write` operation an writer.

When an opener releases its file descriptor this output capability is
usually restored due to the fact that there's only ever one writer and
that writer should have the `opener->type` set to `WRITER`. With the
unconditional update of the `dev->ready_to_output` field this invariant is
broken as a file descriptor starts with a `opener->type` of `UNKNOWN`. Thus
when performing a `write` operation followed by `close` to the file descriptor
the logic to restore the output capabilities does not trigger and the
output capability is lost.

Thus instead of aiding sloppy user-land programming and guessing what
the caller desires this patch makes the `write` operation more strict in
its preconditions by enforcing the file descriptor to belong to an
opener with type `WRITER`. Failure to adhere to this is indicated by
an explicit `EINVAL` error return, as `write` operations as a non-`WRITER`
should not be allowed.

Fixes: #470