### PR TITLE
Release memory on error in `v4l2_loopback_open`

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2005,8 +2005,6 @@ static int v4l2_loopback_open(struct file *file)
 	if (opener == NULL)
 		return -ENOMEM;
 
-	v4l2_fh_init(&opener->fh, video_devdata(file));
-	file->private_data = &opener->fh;
 	atomic_inc(&dev->open_count);
 
 	opener->timeout_image_io = dev->timeout_image_io;
@@ -2017,9 +2015,16 @@ static int v4l2_loopback_open(struct file *file)
 
 		if (r < 0) {
 			dprintk("timeout image allocation failed\n");
+
+			atomic_dec(&dev->open_count);
+
+			kfree(opener);
 			return r;
 		}
 	}
+
+	v4l2_fh_init(&opener->fh, video_devdata(file));
+	file->private_data = &opener->fh;
 
 	v4l2_fh_add(&opener->fh);
 	dprintk("opened dev:%p with image:%p\n", dev, dev ? dev->image : NULL);

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2008,8 +2008,6 @@ static int v4l2_loopback_open(struct file *file)
 	atomic_inc(&dev->open_count);
 
 	opener->timeout_image_io = dev->timeout_image_io;
-	dev->timeout_image_io = 0;
-
 	if (opener->timeout_image_io) {
 		int r = allocate_timeout_image(dev);
 
@@ -2022,6 +2020,8 @@ static int v4l2_loopback_open(struct file *file)
 			return r;
 		}
 	}
+
+	dev->timeout_image_io = 0;
 
 	v4l2_fh_init(&opener->fh, video_devdata(file));
 	file->private_data = &opener->fh;


### PR DESCRIPTION
This resolves a memory leak in case the call to `allocate_timeout_image` fails.

Also (the second commit) changes that the timeout image writing is only honored/reset for successful `open`(2) calls of the device.