### PR TITLE
attr_store_maxopener: Handle integer truncation

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -609,7 +609,7 @@ static ssize_t attr_store_maxopeners(struct device *cd,
 	if (dev->max_openers == curr)
 		return len;
 
-	if (dev->open_count.counter > curr) {
+	if (curr > __INT_MAX__ || dev->open_count.counter > curr) {
 		/* request to limit to less openers as are currently attached to us */
 		return -EINVAL;
 	}


### PR DESCRIPTION
Check if unsigned long passed through sysfs fits into an int.
If not, treat it as invalid value.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>