### PR TITLE
Fix warning with gcc 12

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2460,7 +2460,7 @@ static int v4l2_loopback_add(struct v4l2_loopback_config *conf, int *ret_nr)
 	nr = err;
 	err = -ENOMEM;
 
-	if (conf && conf->card_label && *(conf->card_label)) {
+	if (conf && conf->card_label[0]) {
 		snprintf(dev->card_label, sizeof(dev->card_label), "%s",
 			 conf->card_label);
 	} else {


### PR DESCRIPTION
```
v4l2loopback.c: In function ‘v4l2_loopback_add’:
v4l2loopback.c:2463:18: warning: the comparison will always evaluate as ‘true’ for the address of ‘card_label’ will never be NULL [-Waddress]
 2463 |         if (conf && conf->card_label && *(conf->card_label)) {
      |                  ^~
In file included from v4l2loopback.c:40:
v4l2loopback.h:39:14: note: ‘card_label’ declared here
   39 |         char card_label[32];
      |              ^~~~~~~~~~
```

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>