### PR TITLE
Support `V4L2_PIX_FMT_ABGR32` format

### DIFF
--- a/v4l2loopback_formats.h
+++ b/v4l2loopback_formats.h
@@ -31,6 +31,14 @@ static const struct v4l2l_format formats[] = {
 		.depth = 24,
 		.flags = 0,
 	},
+#ifdef V4L2_PIX_FMT_ABGR32
+	{
+		.name = "32 bpp RGBA, le",
+		.fourcc = V4L2_PIX_FMT_ABGR32,
+		.depth = 32,
+		.flags = 0,
+	},
+#endif
 #ifdef V4L2_PIX_FMT_RGBA32
 	{
 		.name = "32 bpp RGBA",


### PR DESCRIPTION
This is the only lossless pixel format with alpha channel that OBS can consume, so supporting it here would be helpful.