### PR TITLE
v4l2loopback: un-confine v4l2loopback_cleanup_module()

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2951,7 +2951,6 @@ error:
 	return err;
 }
 
-#ifdef MODULE
 static void v4l2loopback_cleanup_module(void)
 {
 	MARK();
@@ -2961,7 +2960,6 @@ static void v4l2loopback_cleanup_module(void)
 	misc_deregister(&v4l2loopback_misc);
 	dprintk("module removed\n");
 }
-#endif
 
 MODULE_ALIAS_MISCDEV(MISC_DYNAMIC_MINOR);
 


### PR DESCRIPTION
@TheArcaneBrony reported this happening when building the `v4l2loopback` as a built-in:

```
drivers/media/v4l2-core/v4l2loopback.c:2969:13: error: use of undeclared identifier 'v4l2loopback_cleanup_module'; did you mean 'v4l2loopback_init_module'?
```

The reason for this is that 550c240585 introduced extra `ifdef MODULE` around `v4l2loopback_cleanup_module()`, but subsequently 1fcd767eb3 opted into using `module_init()`/`module_exit()` instead, which made the `ifdef` excessive.

Hence, remove extra `ifdef MODULE`.

Fixes: 1fcd767eb3 ("use module_init()/module_exit() rather than '#ifdef MODULE'")
Reported-by: The Arcane Brony <myrainbowdash949@gmail.com>
Tested-by: The Arcane Brony <myrainbowdash949@gmail.com>
Signed-off-by: Oleksandr Natalenko <oleksandr@natalenko.name>