### PR TITLE
Fix compilation issues under AOSP

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -118,7 +118,7 @@ static inline void v4l2l_get_timestamp(struct v4l2_buffer *b)
 	b->timestamp.tv_usec = (ts.tv_nsec / NSEC_PER_USEC);
 }
 
-#if !defined(__poll_t)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
 typedef unsigned __poll_t;
 #endif
 


### PR DESCRIPTION
I failed to compile under AOSP, and then I found that __poll_t is defined since kernel 4.16
So, I change one line of code, and that works.

Maybe, #if defined() only works with types like these:
#define __poll_t (unsigned int)

I'm not quite sure. Would you please spend some time to check if this PR is correct?