### PR TITLE
mutex lock access to outbufs_list in vidioc_dqbuf

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1701,9 +1701,11 @@ static int vidioc_dqbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 		*buf = dev->buffers[index].buffer;
 		return 0;
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
+		spin_lock_bh(&dev->lock);
 		b = list_entry(dev->outbufs_list.prev, struct v4l2l_buffer,
 			       list_head);
 		list_move_tail(&b->list_head, &dev->outbufs_list);
+		spin_unlock_bh(&dev->lock);
 		dprintkrw("output DQBUF index: %d\n", b->buffer.index);
 		unset_flags(b);
 		*buf = b->buffer;


### PR DESCRIPTION
this is the minimal fix that resolves the kernel panic described in the issue. However, its certainly not complete.

* there are several other places where the list is accessed, they all should be mutex locked
* the mutex lock is intended to be used for the stats and not for the list, we should spend an extra mutex lock

closes https://github.com/umlaeute/v4l2loopback/issues/532