### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,14 +331,13 @@ If needed, one can specify default module options by creating
 `/etc/modprobe.d/v4l2loopback.conf` in the following form:
 
 ~~~
-options v4l2loopback video_nr=3,4,7
-options v4l2loopback card_label="device number 3,the number four,the last one"
+options v4l2loopback video_nr=3,4,7 card_label="device number 3,the number four,the last one"
 ~~~
 
-One can only add one option per line. These options also become the defaults when
-manually calling `modprobe v4l2loopback`. Note that the double quotes can only
-be used at the beginning and the end of the option's value, as opposed to when
-they are specified on the command line.
+These options also become the defaults when manually calling 
+`modprobe v4l2loopback`. Note that the double quotes can only be used at the 
+beginning and the end of the option's value, as opposed to when they are 
+specified on the command line.
 
 If your system boots with an initial ramdisk, which is the case for most
 modern distributions, you need to update this ramdisk with the settings above,


### PR DESCRIPTION
Someone raised the issue (https://github.com/fangfufu/Linux-Fake-Background-Webcam/issues/190) that the [README](https://github.com/umlaeute/v4l2loopback#load-the-module-at-boot) says
>  One can only add one option per line.

I believe this is wrong, because ArchWiki's [example](https://wiki.archlinux.org/title/Kernel_module#Using_files_in_/etc/modprobe.d/) shows that you can have multiple options per line. 

This commit fixes the README. 