### PR TITLE
Fixed utils build for musl (missing GLOB_ONLYDIR)

### DIFF
--- a/utils/v4l2loopback-ctl.c
+++ b/utils/v4l2loopback-ctl.c
@@ -29,6 +29,10 @@
 
 #include "v4l2loopback.h"
 
+#ifndef GLOB_ONLYDIR
+#define GLOB_ONLYDIR 0 /* Fix for musl libc and other libcs missing GLOB_ONLYDIR at glob.h */
+#endif
+
 #define CONTROLDEVICE "/dev/v4l2loopback"
 
 #if 0


### PR DESCRIPTION
The musl libc is missing `GLOB_ONLYDIR` on Alpine Linux. This PR manually defines `GLOB_ONLYDIR` to `0`, which makes the utils compile and work again. Details:
```
$ apk info --who-owns /usr/include/glob.h 
/usr/include/glob.h is owned by musl-dev-1.2.4_git20230717-r2
```
```c
$ cat /usr/include/glob.h | grep GLOB_
#ifndef _GLOB_H
#define _GLOB_H
#define GLOB_ERR      0x01
#define GLOB_MARK     0x02
#define GLOB_NOSORT   0x04
#define GLOB_DOOFFS   0x08
#define GLOB_NOCHECK  0x10
#define GLOB_APPEND   0x20
#define GLOB_NOESCAPE 0x40
#define GLOB_PERIOD   0x80
#define GLOB_TILDE       0x1000
#define GLOB_TILDE_CHECK 0x4000
#define GLOB_NOSPACE 1
#define GLOB_ABORTED 2
#define GLOB_NOMATCH 3
#define GLOB_NOSYS   4
```
After building and installing with this fix:
```
$ sudo v4l2loopback-ctl list
OUTPUT          CAPTURE         NAME
/dev/video2     /dev/video2     Dummy video device (0x0000)
```