### PR TITLE
Added `v4l2loopback-ctl.o` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.yuv
 Module.symvers
 modules.order
+utils/v4l2loopback-ctl.o
 utils/v4l2loopback-ctl
 v4l2loopback.ko
 v4l2loopback.mod


### PR DESCRIPTION
After building this project, there is an artefact (`v4l2loopback-ctl.o`) not included in the gitignore. Someone could mistakenly upload this by not noticing it is there along with the commit.
This PR adds the said artefact to gitignore to avoid mistakenly pushing it with one's commits.