### PR TITLE
Avoid building utils with dkms

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -16,7 +16,7 @@ if [ -f $kernel_source_dir/.config ]; then
 fi
 
 # Items below here should not have to change with each driver version
-MAKE[0]="make KERNEL_DIR=${kernel_source_dir} all"
+MAKE[0]="make KERNEL_DIR=${kernel_source_dir} v4l2loopback"
 CLEAN="make clean"
 
 BUILT_MODULE_NAME[0]="$PACKAGE_NAME"


### PR DESCRIPTION
This changes the dkms configuration to only build the kernel module, not the utils, i.e. v4l2loopback-ctl.