### PR TITLE
Created attribute active_readers

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -762,6 +762,19 @@ static ssize_t attr_store_maxopeners(struct device *cd,
 static DEVICE_ATTR(max_openers, S_IRUGO | S_IWUSR, attr_show_maxopeners,
 		   attr_store_maxopeners);
 
+static ssize_t attr_show_active_readers(struct device *cd,
+				 struct device_attribute *attr, char *buf)
+{
+	struct v4l2_loopback_device *dev = v4l2loopback_cd2dev(cd);
+
+	if (!dev)
+		return -ENODEV;
+
+	return sprintf(buf, "%d\n", dev->active_readers);
+}
+
+static DEVICE_ATTR(active_readers, S_IRUGO, attr_show_active_readers, NULL);
+
 static ssize_t attr_show_state(struct device *cd, struct device_attribute *attr,
 			       char *buf)
 {
@@ -778,6 +791,7 @@ static ssize_t attr_show_state(struct device *cd, struct device_attribute *attr,
 	return -EAGAIN;
 }
 
+
 static DEVICE_ATTR(state, S_IRUGO, attr_show_state, NULL);
 
 static void v4l2loopback_remove_sysfs(struct video_device *vdev)
@@ -788,6 +802,7 @@ static void v4l2loopback_remove_sysfs(struct video_device *vdev)
 		V4L2_SYSFS_DESTROY(format);
 		V4L2_SYSFS_DESTROY(buffers);
 		V4L2_SYSFS_DESTROY(max_openers);
+		V4L2_SYSFS_DESTROY(active_readers);
 		V4L2_SYSFS_DESTROY(state);
 		/* ... */
 	}
@@ -807,6 +822,7 @@ static void v4l2loopback_create_sysfs(struct video_device *vdev)
 		V4L2_SYSFS_CREATE(format);
 		V4L2_SYSFS_CREATE(buffers);
 		V4L2_SYSFS_CREATE(max_openers);
+		V4L2_SYSFS_CREATE(active_readers);
 		V4L2_SYSFS_CREATE(state);
 		/* ... */
 	} while (0);


### PR DESCRIPTION
The attribute `active_readers` contains the number of openers of a video loopback device that has opened it for streaming (the property `active_readers` or `v4l2_loopback_device`).

This parameter is already provided via a client event `V4L2_EVENT_PRI_CLIENT_USAGE` (emitted each time the loopback device is captured or released), but its value is not easily accessible otherwise, in particular when an application feeding the loopback device starts and no new event has been emitted yet. Exposing this value as an attribute fixes this issue.

I am already using this attribute in an application that feeds a loopback device with a video stream whenever the device is captured. The value of the attribute is checked by the application on start to determine if the device should be fed immediately (for instance after reloading the app due to an error).

