### PR TITLE
Allow repeat REQBUF when buffers not mapped

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1581,8 +1581,13 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 		return 0;
 	}
 
-	if (V4L2_TYPE_IS_OUTPUT(b->type) && (!dev->ready_for_output)) {
-		return -EBUSY;
+	if (V4L2_TYPE_IS_OUTPUT(b->type)) {
+		if (!dev->ready_for_output)
+			return -EBUSY;
+		int i;
+		for (i = 0; i < dev->buffers_number; ++i)
+			if (dev->buffers[i].buffer.flags & V4L2_BUF_FLAG_MAPPED)
+				return -EBUSY;
 	}
 
 	init_buffers(dev);

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1962,8 +1962,11 @@ static int vidioc_streamoff(struct file *file, void *fh,
 	opener = fh_to_opener(fh);
 	switch (type) {
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
-		if (dev->ready_for_capture > 0)
-			dev->ready_for_capture--;
+		if (opener->type == WRITER) {
+			if (dev->ready_for_capture > 0)
+				dev->ready_for_capture--;
+			dev->ready_for_output = 1;
+		}
 		return 0;
 	case V4L2_BUF_TYPE_VIDEO_CAPTURE:
 		if (opener->type == READER) {


### PR DESCRIPTION
Allow repeated VIDIOC_REQBUF when no buffers are mapped (fix #598) by:

1.  Setting `ready_for_output` back to 1 in `vidioc_streamoff`.
2.  Checking that buffers are not mapped in `vidioc_reqbufs` when ready-for-output is true.

I hope I haven't messed up the logic for `dev->ready_for_output`. The comments suggest:

> set to true when no writer is currently attached

More precisely, it looked to me like it was initialised as true and set to false (only) once `vidioc_streamon` is called - i.e. when the output process is started in streaming (memory mapping) I/O. Thus it should be safe to return it to true once `vidioc_streamoff` is called.

I contemplated whether I also needed to add a check that the opener is assigned WRITER type in stream-off, but have left it out for now, e.g.:

```diff
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1964,7 +1964,8 @@ static int vidioc_streamoff(struct file *file, void *fh,
        case V4L2_BUF_TYPE_VIDEO_OUTPUT:
                if (dev->ready_for_capture > 0)
                        dev->ready_for_capture--;
-                dev->ready_for_output = 1;
+                if (opener->type == WRITER)
+                        dev->ready_for_output = 1;
                return 0;
```

