### PR TITLE
v4l2loopback-ctl: Fix for set-timeout-image verb block

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,13 @@ if the producer suddenly stopped.
 $ v4l2-ctl -d /dev/video0 -c timeout=3000
 ~~~
 
-Alternatively, you can calso provide a timeout-image, which will be displayed (instead of the NULL frames),
-if the producer doesn't send any new frames for a given period:
+_Requires GStreamer 1.0, version >= 1.16_: You can provide a timeout image,
+which will be displayed (instead of the NULL frames), if the
+producer doesn't send any new frames for a given period (in the following
+example; 3000ms):
 
 ~~~
 $ v4l2loopback-ctl set-timeout-image -t 3000 /dev/video0 service-unavailable.png
-(this currently requires GStreamer 1.0 installed)
 ~~~
 
 ## DYNAMIC DEVICE MANAGEMENT

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ or
 
     $ v4l2loopback-ctl set-caps /dev/video0 "UYVY:640x480"
 
-Please note that *GStreamer-style caps* (e.g. `video/x-raw,format=UYVY,width=640,height=480`) or no longer supported!
+Please note that *GStreamer-style caps* (e.g. `video/x-raw,format=UYVY,width=640,height=480`) are no longer supported!
 
 ## SETTING STREAM TIMEOUT
 
@@ -323,8 +323,8 @@ dkms install -m v4l2loopback -v ${version}
 | Fedora,...         | gcc kernel-devel dkms |
 | Debian, Ubuntu,... | dkms                  |
 
-
-Note that using this method will NOT install the v4l2loopback-ctl tool, you will have to do it yourself!
+_Note_: Using this method will _NOT_ install the `v4l2loopback-ctl` tool; do so manually via
+`cd utils && make && sudo make install`.
 
 # LOAD THE MODULE AT BOOT
 

--- a/utils/v4l2loopback-ctl.c
+++ b/utils/v4l2loopback-ctl.c
@@ -1071,9 +1071,8 @@ static int set_timeoutimage(const char *devicename, const char *imagefile,
 			 "imagefreeze",
 			 "!",
 			 "identity",
-			 "eos-after=3",
-			 "!",
-			 "tee",
+			 "eos-after=2",
+			 "drop-allocation=1",
 			 "!",
 			 "v4l2sink",
 			 "show-preroll-frame=false",
@@ -1088,7 +1087,7 @@ static int set_timeoutimage(const char *devicename, const char *imagefile,
 	snprintf(devicearg, 4096, "device=%s", devicename);
 	imagearg[4095] = devicearg[4095] = 0;
 	args[2] = imagearg;
-	args[17] = devicearg;
+	args[16] = devicearg;
 
 	fd = open_videodevice(devicename, O_RDWR);
 	if (fd >= 0) {


### PR DESCRIPTION
Small change to __v4l2loopback-ctl__ which fixes a block/hang when the `set-timeout-image` verb is used in __v4l2loopback-ctl__; this fix also depends on #611.

I didn't include it in that PR because the PR was big enough already.

This verb already relied on the `eos_after` attribute (of the `identity` element) that was introduced in 1.16, which means that the `drop_allocation` attribute is also available. When drop allocation is set; the `tee` element is not needed.

Added clarification to the README regarding the version of gstreamer required for this verb.